### PR TITLE
[React useForm]: add isEmpty field to hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,7 @@ Triggers the validation rules for _all_ properties (use this if you want validat
 ### getValue: () => T
 
 Returns your fully formed object. Make sure it's valid first either by disabling your submit button when fields have errors or calling `validate()`, before trying to use it.
+
+### isEmpty: boolean
+
+This value is `true` if all fields of `T` are either: `undefined | null | "" | [] (empty array)`, `false` otherwise. And this value is kept up to date across renders.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-use-form",
+  "name": "@ginger.io/react-use-form",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "printWidth": 80,
     "semi": false,
     "singleQuote": true,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "arrowParens": "avoid"
   },
   "name": "@ginger.io/react-use-form",
   "author": "Ginger",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -41,7 +41,7 @@ export function useForm<T extends Record<string, any>>(
   }, [state])
 
   const getValue = useCallback(() => {
-    return produce(state, (t) => {
+    return produce(state, t => {
       forEach<FieldState<any>>(state, (path, { value }) => {
         set(t, path, value)
       })
@@ -52,7 +52,7 @@ export function useForm<T extends Record<string, any>>(
 }
 
 function getInitialState<T>(fieldDefs: FieldDefinitions<T>): FieldsState<T> {
-  return produce(fieldDefs, (initialState) => {
+  return produce(fieldDefs, initialState => {
     forEach<FieldDefinition<any>>(
       fieldDefs,
       (path, { rules, default: value, __type }) => {
@@ -66,7 +66,7 @@ function createFields<T>(
   state: FieldsState<T>,
   setState: (state: FieldsState<T>) => void
 ): Fields<T> {
-  return (produce(state, (fields) => {
+  return (produce(state, fields => {
     forEach<FieldState<any>>(
       state,
       (path, { value, error, touched, rules }) => {
@@ -75,17 +75,15 @@ function createFields<T>(
           error,
           touched,
           onChange: (updatedValue: any) => {
-            const updatedState = produce(state, (updatedState) => {
+            const updatedState = produce(state, updatedState => {
               set(updatedState, [...path, 'value'], updatedValue)
               set(updatedState, [...path, 'touched'], true)
             })
             setState(updatedState)
           },
           onBlur: () => {
-            const updatedState = produce(state, (updatedState) => {
-              const error = rules
-                .map((r) => r(value))
-                .find((_) => _ !== undefined)
+            const updatedState = produce(state, updatedState => {
+              const error = rules.map(r => r(value)).find(_ => _ !== undefined)
               set(updatedState, [...path, 'error'], error)
             })
             setState(updatedState)
@@ -101,10 +99,10 @@ function runValidation<T>(
   setState: (state: FieldsState<T>) => void
 ): boolean {
   let isValid = true
-  const updatedState = produce(state, (updatedState) => {
+  const updatedState = produce(state, updatedState => {
     forEach(state, (path, field) => {
       const { rules, value } = (field as unknown) as FieldState<T>
-      const error = rules.map((r) => r(value)).find((_) => _ !== undefined)
+      const error = rules.map(r => r(value)).find(_ => _ !== undefined)
       set(updatedState, [...path, 'error'], error)
       if (error) {
         isValid = false

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -35,6 +35,51 @@ describe('useForm', () => {
     expect(fields.components.value).toEqual(undefined)
   })
 
+  it('should set isEmpty to true when all fields undefined', () => {
+    const { result } = render<Widget>({
+      name: field(),
+      components: field(),
+      details: {
+        description: field(),
+        picture: field()
+      }
+    })
+
+    const { isEmpty } = result.current
+    expect(isEmpty).toEqual(true)
+  })
+
+  it('should set isEmpty to true when fields contain the empty string or null', () => {
+    const { result } = render<Widget>({
+      name: field({ default: '' }),
+      components: field<Component[]>({ default: [] }),
+      details: {
+        description: field({ default: null } as any),
+        picture: field()
+      }
+    })
+
+    const { isEmpty } = result.current
+    expect(isEmpty).toEqual(true)
+  })
+
+  it('should set isEmpty to false when fields contain a value', () => {
+    const { result } = render<Widget>({
+      name: field(),
+      components: field(),
+      details: {
+        description: field(),
+        picture: field()
+      }
+    })
+
+    act(() => {
+      result.current.fields.name.onChange('Widget A')
+    })
+
+    expect(result.current.isEmpty).toEqual(false)
+  })
+
   it('should require every field by default', async () => {
     const { result } = render<Widget>({
       name: field(),


### PR DESCRIPTION
This PR adds an `isEmpty` value which makes it easy to determine if the form state has any value populated or none. 