### PR TITLE
[React useForm]: Handle multiple onChange events in the same render cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -166,17 +166,8 @@ describe('useForm', () => {
 
     act(() => {
       result.current.fields.name.onChange('Widget A')
-    })
-
-    act(() => {
       result.current.fields.components.onChange([])
-    })
-
-    act(() => {
       result.current.fields.details.description.onChange('Description')
-    })
-
-    act(() => {
       result.current.fields.details.picture.onChange('Picture')
     })
 


### PR DESCRIPTION
This PR fixes a subtle bug where we'd fail to capture updates due to stale state if you called multiple `onChange` handlers within the same React render cycle. 

To give a concrete example, you might have a React component for `Date`, and when the date changes you might do something like: 

```TypeScript
const onClick = () => { // somebody clicked a date in our date picker widget
  fields.day.onChange(...)
  fields.month.onChange(...)
  fields.year.onChange(...)
}
```

Prior to this PR, that would fail and you'd only see `year` get set with the other two fields being `undefined`. This would occur because the `state` variable we were using would become stale, but only within the same render cycle. 
