### PR TITLE
[React useForm]: Short-circuit isEmpty

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.4.",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
This PR makes a small optimization resulting from a comment thread in this PR: https://github.com/ginger-io/react-use-form/pull/1#discussion_r450504289

Basically @aboisvert  caught me being lazy :). So, here we become less lazy by bailing out early when calculating our `isEmpty` value. 