### PR TITLE
[React Hook Form]: Allow passing a fully-formed T as a top-level default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,39 @@ function NumberField(props: { label: string; field: Field<number> }) {
 }
 ```
 
-## API
+## Hook API
 
-### fields
+```TypeScript
 
-A recursive mirror of your object, where each field is a `Field<T>` with the following properities:
+type UseForm<T> = {
+  fields: Fields<T> // field bindings
+  validate: () => boolean // trigger validation
+  getValue: () => T // retrieve the current form value
+  isEmpty: boolean // true if all fields are undefined, null or ""
+}
+
+function useForm<T>(fieldDefinitions: FieldDefinitions<T>, defaultValue?: T): UseForm<T>
+```
+
+### fields: Fields<T>
+
+A recursive mirror of your object, where each field is a `Field<T>`.
+
+### validate: () => boolean
+
+Triggers the validation rules for _all_ properties (use this if you want validation errors to show up _after_ the user clicks your submit button vs right away with `onBlur`).
+
+### getValue: () => T
+
+Returns your fully formed object. Make sure it's valid first either by disabling your submit button when fields have errors or calling `validate()`, before trying to use it.
+
+### isEmpty: boolean
+
+This value is `true` if all fields of `T` are either: `undefined | null | "" | [] (empty array)`, `false` otherwise. And this value is kept up to date across renders.
+
+## Field<T> API
+
+A `Field<T>` represents the state for a specific field on your object, with the following properties:
 
 #### value: T
 
@@ -111,14 +139,19 @@ The first error triggered by your validation rules or `undefined`
 
 The `onBlur` handler for this property. Calling this triggers the validation rules for this property and triggers a re-render.
 
-### validate: () => boolean
+## Default Values
 
-Triggers the validation rules for _all_ properties (use this if you want validation errors to show up _after_ the user clicks your submit button vs right away with `onBlur`).
+There are two ways to specify a default value:
 
-### getValue: () => T
+1. Pass a fully formed `T` as the second parameter to `useForm`, e.g. `useForm({...}, defaultValue)`.
+   This is useful when you have an existing object from your API and you want to "edit" it in your form.
 
-Returns your fully formed object. Make sure it's valid first either by disabling your submit button when fields have errors or calling `validate()`, before trying to use it.
+2. Pass a default value for a specific field, using the `field` helper method -- e.g:
 
-### isEmpty: boolean
+```TypeScript
+useForm({
+  name: field({ default: "foo" })
+})
+```
 
-This value is `true` if all fields of `T` are either: `undefined | null | "" | [] (empty array)`, `false` otherwise. And this value is kept up to date across renders.
+Note: Field-level defaults override top-level defaults.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/react-use-form",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1541,6 +1541,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.157.tgz",
       "integrity": "sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==",
       "dev": true
+    },
+    "@types/lodash.get": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
+      "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/lodash.set": {
       "version": "4.3.6",
@@ -5478,6 +5487,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@testing-library/react-hooks": "^3.3.0",
     "@types/jest": "^26.0.4",
+    "@types/lodash.get": "^4.4.6",
     "@types/lodash.set": "^4.3.6",
     "@types/react": "^16.9.41",
     "@types/react-dom": "^16.9.8",
@@ -51,6 +52,7 @@
   },
   "dependencies": {
     "immer": "^7.0.5",
+    "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2"
   }
 }

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -27,7 +27,7 @@ export function useForm<T extends Record<string, any>>(
   ])
   const [state, setState] = useState<FieldsState<T>>(initialState)
   const fields = useMemo(() => createFields(state, setState), [state])
-  const validate = useCallback(() => runValidation(setState), [state])
+  const validate = useCallback(() => runValidation(setState), [setState])
 
   const isEmpty = useMemo(() => {
     const hasValue = exists<FieldsState<T>>(

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -1,5 +1,6 @@
 import produce from 'immer'
 import set from 'lodash.set'
+import get from 'lodash.get'
 import { useCallback, useMemo, useState } from 'react'
 import {
   FieldDefinition,
@@ -17,9 +18,13 @@ export type UseForm<T> = {
 }
 
 export function useForm<T extends Record<string, any>>(
-  fieldDefs: FieldDefinitions<T>
+  fieldDefs: FieldDefinitions<T>,
+  defaultValue?: T
 ): UseForm<T> {
-  const initialState = useMemo(() => getInitialState(fieldDefs), [fieldDefs])
+  const initialState = useMemo(() => getInitialState(fieldDefs, defaultValue), [
+    fieldDefs,
+    defaultValue
+  ])
   const [state, setState] = useState<FieldsState<T>>(initialState)
   const fields = useMemo(() => createFields(state, setState), [state])
   const validate = useCallback(() => runValidation(setState), [state])
@@ -44,11 +49,15 @@ export function useForm<T extends Record<string, any>>(
   return { getValue, validate, fields, isEmpty }
 }
 
-function getInitialState<T>(fieldDefs: FieldDefinitions<T>): FieldsState<T> {
+function getInitialState<T>(
+  fieldDefs: FieldDefinitions<T>,
+  defaultValue?: T
+): FieldsState<T> {
   return produce(fieldDefs, initialState => {
     forEach<FieldDefinition<any>>(
       fieldDefs,
-      (path, { rules, default: value, __type }) => {
+      (path, { rules, default: defaultFieldValue, __type }) => {
+        const value = defaultFieldValue || get(defaultValue, path)
         set(initialState, path, { rules, value, __type })
       }
     )

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -145,6 +145,64 @@ describe('useForm', () => {
     expect(fields.components.value).toEqual([])
   })
 
+  it('should allow passing a fully formed T as a default', () => {
+    const existingWidget: Widget = {
+      name: 'Widget',
+      components: [{ id: 'component-1' }],
+      details: {
+        description: 'Description',
+        picture: 'Picture'
+      }
+    }
+
+    const { result } = render<Widget>(
+      {
+        name: field(),
+        components: field(),
+        details: {
+          description: field(),
+          picture: field()
+        }
+      },
+      existingWidget
+    )
+
+    const { fields } = result.current
+    expect(fields.name.value).toEqual('Widget')
+    expect(fields.details.description.value).toEqual('Description')
+    expect(fields.details.picture.value).toEqual('Picture')
+    expect(fields.components.value).toEqual([{ id: 'component-1' }])
+  })
+
+  it('should have field-level defaults supersede full object default', () => {
+    const existingWidget: Widget = {
+      name: 'Widget',
+      components: [{ id: 'component-1' }],
+      details: {
+        description: 'Description',
+        picture: 'Picture'
+      }
+    }
+
+    const { result } = render<Widget>(
+      {
+        name: field({ default: 'Supersede!' }),
+        components: field(),
+        details: {
+          description: field(),
+          picture: field()
+        }
+      },
+      existingWidget
+    )
+
+    const { fields } = result.current
+    expect(fields.name.value).toEqual('Supersede!')
+    expect(fields.details.description.value).toEqual('Description')
+    expect(fields.details.picture.value).toEqual('Picture')
+    expect(fields.components.value).toEqual([{ id: 'component-1' }])
+  })
+
   it('should change the value and extract the full value', async () => {
     const { result } = render<Widget>({
       name: field(),
@@ -209,7 +267,8 @@ describe('useForm', () => {
 })
 
 function render<T>(
-  fieldDefs: FieldDefinitions<T>
+  fieldDefs: FieldDefinitions<T>,
+  defaultValue?: T
 ): RenderHookResult<unknown, UseForm<T>> {
-  return renderHook(() => useForm(fieldDefs))
+  return renderHook(() => useForm(fieldDefs, defaultValue))
 }


### PR DESCRIPTION
This PR adds a feature to allow callers to pass a fully-formed domain object to use as a "default" for your form state. The intended use-case here is for "edit" or "read-only" forms, where you want to pre-populate all the fields. 