### PR TITLE
[React Use Form]: Fix a bug with validate() that only appears on an async state update

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ function PersonForm(props: {}) {
     }
   })
 
-  const onSubmit = () => {
-    if (validate()) { // trigger validation
+  const onSubmit = async () => {
+    if (await validate()) { // trigger validation
       console.log(getValue()) // get your fully-formed Person
     }
   }
@@ -107,7 +107,7 @@ function useForm<T>(fieldDefinitions: FieldDefinitions<T>, defaultValue?: T): Us
 
 A recursive mirror of your object, where each field is a `Field<T>`.
 
-### validate: () => boolean
+### validate: () => Promise<boolean>
 
 Triggers the validation rules for _all_ properties (use this if you want validation errors to show up _after_ the user clicks your submit button vs right away with `onBlur`).
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -92,8 +92,8 @@ describe('useForm', () => {
 
     const { validate } = result.current
     let isValid = undefined
-    act(() => {
-      isValid = validate()
+    await act(async () => {
+      isValid = await validate()
     })
 
     const { fields } = result.current
@@ -116,8 +116,8 @@ describe('useForm', () => {
 
     const { validate } = result.current
     let isValid = undefined
-    act(() => {
-      isValid = validate()
+    await act(async () => {
+      isValid = await validate()
     })
 
     const { fields } = result.current
@@ -249,20 +249,24 @@ describe('useForm', () => {
       components: field()
     })
 
-    act(() => {
+    let firstValidation: boolean | undefined = undefined
+    await act(async () => {
       result.current.fields.name.onChange('Widget A')
       result.current.fields.components.onChange([])
       result.current.fields.details.description.onChange('Description')
       result.current.fields.details.picture.onChange('Picture')
+      firstValidation = await result.current.validate()
     })
 
-    expect(result.current.validate()).toEqual(true)
+    expect(firstValidation).toEqual(true)
 
-    act(() => {
+    let secondValidation: boolean | undefined = undefined
+    await act(async () => {
       result.current.fields.name.onChange('')
+      secondValidation = await result.current.validate()
     })
 
-    expect(result.current.validate()).toEqual(false)
+    expect(secondValidation).toEqual(false)
   })
 
   it('should reset field value to default', async () => {


### PR DESCRIPTION
This PR fixes a bug with the `validate()` function that would only occur if/when React decides to apply the results of a `setState` call asynchronously (see React [docs](https://reactjs.org/docs/state-and-lifecycle.html#state-updates-may-be-asynchronous) for more details on when/why React might decide to do this).

The bug was caused by keeping a local variable, `isValid` outside of the `setState` call. This worked so long as React applied the passed function to `setState` immediately, but broke if React decided to make the update asynchronously. 

To solve this, I just wrapped `setState` in a `Promise` and have `validate()` return that. This technically is a breaking change, but an easy update for library consumers as all they have to do is prepend `await` on the `validate()` call. 
