### PR TITLE
[react-use-form]: Enhancements resulting from PR discussion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ React `useForm` is a custom [hook](https://reactjs.org/docs/hooks-intro.html) th
 
 In React, you often need to extract form data and map it to the shape that your backend API expects -- e.g. a graphQL type. This can quickly get complicated when your object contains nested types (e.g. `person.address.street`). The `useForm` hook makes this easy.
 
-Just specify your object's shape + validation rules and `useForm` gives you a `fields` object with properties that recursively mirror your object (e.g. `person.address.street.value`, `person.address.street.error`, `person.address.street.onChange` etc). You bind those to input components of your choice (e.g. `<TextField field={person.address.street} />`) Then, when the user clicks your "submit" button, simply call `getValue()` to get your fully-formed object out -- no manual data mapping required.
+Just specify your object's shape + validation rules and `useForm` gives you a `fields` object with properties that recursively mirror your object (e.g. `person.address.street.value`, `person.address.street.error`, `person.address.street.setValue` etc). You bind those to input components of your choice (e.g. `<TextField field={person.address.street} />`) Then, when the user clicks your "submit" button, simply call `getValue()` to get your fully-formed object out -- no manual data mapping required.
 
 ## Installation
 
@@ -66,7 +66,7 @@ function TextField(props: { label: string; field: Field<string> }) {
       <input
         type="text"
         value={field.value}
-        onChange={e => field.onChange(e.target.value)}
+        onChange={e => field.setValue(e.target.value)}
       />
       <p>{field.error}</p>
     </>
@@ -81,7 +81,7 @@ function NumberField(props: { label: string; field: Field<number> }) {
       <input
         type="number"
         value={field.value}
-        onChange={e => field.onChange(parseInt(e.target.value))}
+        onChange={e => field.setValue(parseInt(e.target.value))}
       />
       <p>{field.error}</p>
     </>
@@ -109,7 +109,7 @@ A recursive mirror of your object, where each field is a `Field<T>`.
 
 ### validate: () => Promise<boolean>
 
-Triggers the validation rules for _all_ properties (use this if you want validation errors to show up _after_ the user clicks your submit button vs right away with `onBlur`).
+Triggers the validation rules for _all_ properties (use this if you want validation errors to show up _after_ the user clicks your submit button vs right away with `fields.foo.validate`).
 
 ### getValue: () => T
 
@@ -127,17 +127,17 @@ A `Field<T>` represents the state for a specific field on your object, with the 
 
 The current value of this property (changes across renders)
 
-#### onChange<T>(input: T) => void
+#### setValue<T>(input: T) => void
 
-The `onChange` handler for this property. Passing a new value triggers a re-render of your form.
+The `setValue` handler for this property. Passing a new value triggers a re-render of your form.
 
 #### error: string | undefined
 
 The first error triggered by your validation rules or `undefined`
 
-#### onBlur: () => void
+#### validate: () => void
 
-The `onBlur` handler for this property. Calling this triggers the validation rules for this property and triggers a re-render.
+The `validate` handler for this property. Calling this triggers the validation rules for this property and triggers a re-render.
 
 ## Default Values
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ A `Field<T>` represents the state for a specific field on your object, with the 
 
 The current value of this property (changes across renders)
 
-#### setValue<T>(input: T) => void
+#### setValue<T>(input: T, options?: { runValidation: boolean }) => Promise<boolean> | void
 
-The `setValue` handler for this property. Passing a new value triggers a re-render of your form.
+The `setValue` handler for this property. Passing a new value triggers a re-render of your form. Normally this function returns `void`.
+
+But if you want to update your field value _and_ run validation at the same time, you can pass `{ runValidation: true }`. And, when you do the TS type signature will automatically change to `Promise<boolean>`, which you can use to determine if your field passed validation or not.
 
 #### error: string | undefined
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ginger.io/react-use-form",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -7,9 +7,27 @@ export type Field<T> = {
   touched: boolean
   error?: string
   rules: ValidationRule<T>[]
-  setValue: (value: T) => void
+  setValue: <
+    U extends SetValueOptions | EmptySetValueOptions = EmptySetValueOptions
+  >(
+    value: T,
+    options?: U
+  ) => SetValueReturnType<U>
   reset: () => void
   validate: () => void
+}
+
+/** The return type of the setValue function, which can vary based on the options passed in */
+export type SetValueReturnType<T> = T extends EmptySetValueOptions
+  ? void
+  : Promise<boolean>
+
+export type EmptySetValueOptions = {
+  __type: 'empty'
+}
+
+export type SetValueOptions = {
+  runValidation: boolean
 }
 
 export type FieldState<T> = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -7,9 +7,9 @@ export type Field<T> = {
   touched: boolean
   error?: string
   rules: ValidationRule<T>[]
-  onChange: (value: T) => void
+  setValue: (value: T) => void
   reset: () => void
-  onBlur: () => void
+  validate: () => void
 }
 
 export type FieldState<T> = {

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -69,7 +69,10 @@ function getInitialState<T>(
     forEach<FieldDefinition<any>>(
       fieldDefs,
       (path, { rules, default: defaultFieldValue, __type }) => {
-        const value = defaultFieldValue || get(defaultValue, path)
+        const value =
+          defaultFieldValue !== undefined
+            ? defaultFieldValue
+            : defaultFieldValue || get(defaultValue, path)
         set(initialState, path, { rules, value, __type })
       }
     )

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -100,7 +100,7 @@ function createFields<T>(
               | EmptySetValueOptions = EmptySetValueOptions
           >(
             updatedValue: any,
-            options: SetValueOptions | undefined = undefined
+            options?: SetValueOptions
           ): SetValueReturnType<U> => {
             const isValid = new Promise<boolean>(resolve => {
               setState(currentState =>

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -85,12 +85,12 @@ function createFields<T>(
           value,
           error,
           touched,
-          // For onChange / onBlur, we use a "functional" setState call
+          // For setValue / validate, we use a "functional" setState call
           // (https://reactjs.org/docs/hooks-reference.html#functional-updates)
-          // This avoids issues related to stale state when multiple onChange functions are
+          // This avoids issues related to stale state when multiple setValue functions are
           // invoked within the same render cycle -- e.g.
-          // const onClick = () => { date.day.onChange(...); date.day.onChange(...) }:
-          onChange: (updatedValue: any) => {
+          // const onClick = () => { date.day.setValue(...); date.day.setValue(...) }:
+          setValue: (updatedValue: any) => {
             setState(currentState =>
               produce(currentState, updatedState => {
                 set(updatedState, [...path, 'value'], updatedValue)
@@ -108,7 +108,7 @@ function createFields<T>(
               })
             )
           },
-          onBlur: () => {
+          validate: () => {
             setState(currentState =>
               produce(currentState, updatedState => {
                 const error = rules

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -74,7 +74,7 @@ describe('useForm', () => {
     })
 
     act(() => {
-      result.current.fields.name.onChange('Widget A')
+      result.current.fields.name.setValue('Widget A')
     })
 
     expect(result.current.isEmpty).toEqual(false)
@@ -223,10 +223,10 @@ describe('useForm', () => {
     }
 
     act(() => {
-      result.current.fields.name.onChange('Widget A')
-      result.current.fields.components.onChange([])
-      result.current.fields.details.description.onChange('Description')
-      result.current.fields.details.picture.onChange('Picture')
+      result.current.fields.name.setValue('Widget A')
+      result.current.fields.components.setValue([])
+      result.current.fields.details.description.setValue('Description')
+      result.current.fields.details.picture.setValue('Picture')
     })
 
     const { fields, getValue } = result.current
@@ -251,10 +251,10 @@ describe('useForm', () => {
 
     let firstValidation: boolean | undefined = undefined
     await act(async () => {
-      result.current.fields.name.onChange('Widget A')
-      result.current.fields.components.onChange([])
-      result.current.fields.details.description.onChange('Description')
-      result.current.fields.details.picture.onChange('Picture')
+      result.current.fields.name.setValue('Widget A')
+      result.current.fields.components.setValue([])
+      result.current.fields.details.description.setValue('Description')
+      result.current.fields.details.picture.setValue('Picture')
       firstValidation = await result.current.validate()
     })
 
@@ -262,7 +262,7 @@ describe('useForm', () => {
 
     let secondValidation: boolean | undefined = undefined
     await act(async () => {
-      result.current.fields.name.onChange('')
+      result.current.fields.name.setValue('')
       secondValidation = await result.current.validate()
     })
 
@@ -280,7 +280,7 @@ describe('useForm', () => {
     })
 
     act(() => {
-      result.current.fields.name.onChange('Widget A')
+      result.current.fields.name.setValue('Widget A')
     })
 
     expect(result.current.fields.name.value).toEqual('Widget A')
@@ -305,13 +305,13 @@ describe('useForm', () => {
     })
 
     act(() => {
-      result.current.fields.name.onChange('Widget A')
+      result.current.fields.name.setValue('Widget A')
     })
 
     expect(result.current.fields.name.value).toEqual('Widget A')
 
     act(() => {
-      result.current.fields.name.onChange('')
+      result.current.fields.name.setValue('')
       result.current.validate()
     })
     expect(result.current.fields.name.error).toBeDefined()
@@ -346,8 +346,8 @@ describe('useForm', () => {
     )
 
     act(() => {
-      result.current.fields.name.onChange('Updated Widget')
-      result.current.fields.details.description.onChange('Updated Description')
+      result.current.fields.name.setValue('Updated Widget')
+      result.current.fields.details.description.setValue('Updated Description')
     })
 
     expect(result.current.fields.name.value).toEqual('Updated Widget')

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -84,6 +84,22 @@ describe('useForm', () => {
     expect(result.current.isEmpty).toEqual(false)
   })
 
+  it('should allow false-y values as default values', () => {
+    type SomeType = {
+      name: string
+      isPresent: boolean
+    }
+
+    const { result } = render<SomeType>({
+      name: field({ default: '', rules: [] }), // empty strings are falsey in JS, e.g. "" || "foo" => "foo"
+      isPresent: field<boolean>({ default: false, rules: [] })
+    })
+
+    const { fields } = result.current
+    expect(fields.name.value).toEqual('')
+    expect(fields.isPresent.value).toEqual(false)
+  })
+
   it('should require every field by default', async () => {
     const { result } = render<Widget>({
       name: field(),


### PR DESCRIPTION
This PR updates our `react-use-form` library with a few enhancements. The impetus for these changes was a PR discussion with @vly-ginger , where we had a use case that wanted to run validation at the same time a field's value was updated and ship the validation result to the (React) parent component.

Specifically this PR makes the following changes: 

1. `onChange` and `onBlur` are renamed to `setValue` and `validate` respectively. This should help clarify things for callers when their use case doesn't map directly onto the DOM's event handlers. 

2. `setValue` now allows you to run validation in the same render-cycle as the field value update via a `{ runValidation: true }` option. When you pass this option, the TS typings are fancy enough to change the return type of `setValue` from `void` to  `Promise<boolean>`, which tells you if your (new) field value is valid or not.

For easy reviewing, I'd recommend viewing this PR commit-by-commit so you can split the method renames from the logic changes. 