### PR TITLE
[react-use-form]: Allow empty strings as default values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.9",
+  "version": "0.1.10",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -70,8 +70,8 @@ function getInitialState<T>(
       fieldDefs,
       (path, { rules, default: defaultFieldValue, __type }) => {
         const value =
-          defaultFieldValue === ''
-            ? ''
+          defaultFieldValue !== undefined
+            ? defaultFieldValue
             : defaultFieldValue || get(defaultValue, path)
         set(initialState, path, { rules, value, __type })
       }

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -69,7 +69,10 @@ function getInitialState<T>(
     forEach<FieldDefinition<any>>(
       fieldDefs,
       (path, { rules, default: defaultFieldValue, __type }) => {
-        const value = defaultFieldValue || get(defaultValue, path)
+        const value =
+          defaultFieldValue === ''
+            ? ''
+            : defaultFieldValue || get(defaultValue, path)
         set(initialState, path, { rules, value, __type })
       }
     )

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -84,6 +84,23 @@ describe('useForm', () => {
     expect(result.current.isEmpty).toEqual(false)
   })
 
+  it('should allow empty strings as default values', () => {
+    const { result } = render<Widget>({
+      name: field({ default: '' }),
+      components: field(),
+      details: {
+        description: field({ default: '' }),
+        picture: field({ default: '' })
+      }
+    })
+
+    const { fields } = result.current
+    expect(fields.name.value).toEqual('')
+    expect(fields.details.description.value).toEqual('')
+    expect(fields.details.picture.value).toEqual('')
+    expect(fields.components.value).toEqual(undefined)
+  })
+
   it('should require every field by default', async () => {
     const { result } = render<Widget>({
       name: field(),

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -84,21 +84,20 @@ describe('useForm', () => {
     expect(result.current.isEmpty).toEqual(false)
   })
 
-  it('should allow empty strings as default values', () => {
-    const { result } = render<Widget>({
-      name: field({ default: '' }),
-      components: field(),
-      details: {
-        description: field({ default: '' }),
-        picture: field({ default: '' })
-      }
+  it('should allow false-y values as default values', () => {
+    type SomeType = {
+      name: string
+      isPresent: boolean
+    }
+
+    const { result } = render<SomeType>({
+      name: field({ default: '', rules: [] }), // empty strings are falsey in JS, e.g. "" || "foo" => "foo"
+      isPresent: field<boolean>({ default: false, rules: [] })
     })
 
     const { fields } = result.current
     expect(fields.name.value).toEqual('')
-    expect(fields.details.description.value).toEqual('')
-    expect(fields.details.picture.value).toEqual('')
-    expect(fields.components.value).toEqual(undefined)
+    expect(fields.isPresent.value).toEqual(false)
   })
 
   it('should require every field by default', async () => {


### PR DESCRIPTION
This PR fixes a bug where if you passed `field({ default: '' })` and called `getValue()` you'd get `undefined` back for your field value. 

The root cause is we were basically doing `"" || foo` in the code. And JS has an annoying quirk where it considers `""` to be a false-y value. 