### PR TITLE
[React Use Form]: Make full-object defaults supersede field-level defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,4 +156,6 @@ useForm({
 })
 ```
 
-Note: Field-level defaults override top-level defaults.
+Note: If you pass a fully formed object to seed your form values, those object's values will supersede
+any field-level default values you've specified. This is desireable for the intended usecase of loading
+a pre-existing entity/draft into your form.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache 2.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/useForm.tsx
+++ b/src/useForm.tsx
@@ -64,10 +64,14 @@ function getInitialState<T>(
     forEach<FieldDefinition<any>>(
       fieldDefs,
       (path, { rules, default: defaultFieldValue, __type }) => {
-        const value =
-          defaultFieldValue !== undefined
-            ? defaultFieldValue
-            : defaultFieldValue || get(defaultValue, path)
+        // Our "preferredDefaultFieldValue" is the field value that comes in from
+        // an optionally passed full-object (T here). This allows callers to
+        // seed their form with a value pulled down from the network/local storage etc.
+
+        // If a full object is not passed, then we want to fall back to an individual field's
+        // default
+        const preferredDefaultFieldValue = get(defaultValue, path)
+        const value = preferredDefaultFieldValue ?? defaultFieldValue
         set(initialState, path, { rules, value, __type })
       }
     )

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -229,7 +229,7 @@ describe('useForm', () => {
     expect(fields.components.value).toEqual([{ id: 'component-1' }])
   })
 
-  it('non-undefined field-level defaults should supercede undefined fields on a fully formed T', () => {
+  it('non-undefined field-level defaults should supersede undefined fields on a fully formed T', () => {
     const existingWidget: Widget = {
       name: undefined as any,
       components: undefined as any,
@@ -258,7 +258,9 @@ describe('useForm', () => {
     expect(fields.components.value).toEqual([])
   })
 
-  it('should have field-level defaults supersede full object default', () => {
+  // This behavior is desireable to allow callers to seed form values from
+  // an object retrieved from the network / local storage etc.
+  it('should have full object default supersede field-level defaults', () => {
     const existingWidget: Widget = {
       name: 'Widget',
       components: [{ id: 'component-1' }],
@@ -270,10 +272,10 @@ describe('useForm', () => {
 
     const { result } = render<Widget>(
       {
-        name: field({ default: 'Supersede!' }),
+        name: field({ default: 'field level name' }),
         components: field(),
         details: {
-          description: field(),
+          description: field({ default: 'field level description' }),
           picture: field()
         }
       },
@@ -281,7 +283,7 @@ describe('useForm', () => {
     )
 
     const { fields } = result.current
-    expect(fields.name.value).toEqual('Supersede!')
+    expect(fields.name.value).toEqual('Widget')
     expect(fields.details.description.value).toEqual('Description')
     expect(fields.details.picture.value).toEqual('Picture')
     expect(fields.components.value).toEqual([{ id: 'component-1' }])


### PR DESCRIPTION
This PR changes the behavior of how `react-use-form` fills in default values. 

Previously field-level defaults would supersede defaults derived from a full entity the caller could optionally provide. E.g. If I loaded a `Widget` from the network, with `{ name: "my widget" }` and passed that as a default, and also specified a field-level default of `foo: field({ default: "" })` -- we'd get `""`.

This PR swaps that behavior (so now we'd get `"my widget"`). This behavior is nicer for the intended use-case which is to seed form values with an entity loaded from the network/local storage.  In that scenario you want the entity's values to overwrite the default values for each (empty) field. 