### PR TITLE
Add positiveNumberField and nonNegativeNumberField defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 .cache
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ A boolean field whose default value is `false`.
 
 A number field whose default value is `0`.
 
+#### positiveNumberField()
+
+A number field whose default value is `1` and requires positive numbers.
+
+#### nonNegativeNumberField()
+
+A number field whose default value is `0` and requires non-negative numbers (0 and higher).
+
 #### arrayField()
 
 An array field whose default value is `[]`.

--- a/src/fields.tsx
+++ b/src/fields.tsx
@@ -1,4 +1,10 @@
-import { nonEmpty, required, ValidationRule } from './rules'
+import {
+  nonEmpty,
+  nonNegativeNumber,
+  positiveNumber,
+  required,
+  ValidationRule
+} from './rules'
 import { FieldDefinition } from './types'
 
 export type FieldProps<T> = {
@@ -30,6 +36,18 @@ export function numberField(
   props?: FieldProps<number>
 ): FieldDefinition<number> {
   return field({ default: 0, ...props })
+}
+
+export function positiveNumberField(
+  props?: FieldProps<number>
+): FieldDefinition<number> {
+  return field({ default: 1, rules: [positiveNumber], ...props })
+}
+
+export function nonNegativeNumberField(
+  props?: FieldProps<number>
+): FieldDefinition<number> {
+  return field({ default: 0, rules: [nonNegativeNumber], ...props })
 }
 
 export function arrayField<T>(props?: FieldProps<T[]>): FieldDefinition<T[]> {

--- a/src/rules.tsx
+++ b/src/rules.tsx
@@ -22,12 +22,12 @@ export const nonEmpty: ValidationRule<Array<any>, any> = input => {
 
 export const positiveNumber: ValidationRule<number, any> = value => {
   return value === undefined || value === null || value <= 0
-    ? 'This field needs to be greater than zero.'
+    ? 'This field must be greater than zero.'
     : undefined
 }
 
 export const nonNegativeNumber: ValidationRule<number, any> = value => {
   return value === undefined || value === null || value < 0
-    ? 'This field needs to be greater than or equal to zero.'
+    ? 'This field must be greater than or equal to zero.'
     : undefined
 }

--- a/src/rules.tsx
+++ b/src/rules.tsx
@@ -19,3 +19,15 @@ export const nonEmpty: ValidationRule<Array<any>, any> = input => {
     ? "This field can't be empty."
     : undefined
 }
+
+export const positiveNumber: ValidationRule<number, any> = value => {
+  return value === undefined || value === null || value <= 0
+    ? 'This field needs to be greater than zero.'
+    : undefined
+}
+
+export const nonNegativeNumber: ValidationRule<number, any> = value => {
+  return value === undefined || value === null || value < 0
+    ? 'This field needs to be greater than or equal to zero.'
+    : undefined
+}

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -6,6 +6,8 @@ import {
   nonEmptyArrayField,
   numberField,
   stringField,
+  positiveNumberField,
+  nonNegativeNumberField,
   useForm,
   UseForm
 } from '../src/index'
@@ -113,7 +115,7 @@ describe('useForm', () => {
     }
 
     const { result } = render<SomeType>({
-      name: field({ default: '', rules: [] }), // empty strings are falsey in JS, e.g. "" || "foo" => "foo"
+      name: field({ default: '', rules: [] }), // empty strings are falsy in JS, e.g. "" || "foo" => "foo"
       isPresent: field<boolean>({ default: false, rules: [] })
     })
 
@@ -245,7 +247,7 @@ describe('useForm', () => {
     expect(fields.components.value).toEqual([])
   })
 
-  // This behavior is desireable to allow callers to seed form values from
+  // This behavior is desirable to allow callers to seed form values from
   // an object retrieved from the network / local storage etc.
   it('should have full object default supersede field-level defaults', () => {
     const existingWidget: Widget = {
@@ -554,6 +556,88 @@ describe('useForm', () => {
     const { fields } = result.current
     expect(isValid).toBeFalsy()
     expect(fields.arrayField.error).toEqual("This field can't be empty.")
+  })
+
+  it('should not allow zero for positiveNumber rule by default', async () => {
+    type SpecificObject = { positiveNumber: number }
+
+    const { result } = render<SpecificObject>({
+      positiveNumber: positiveNumberField()
+    })
+
+    act(() => {
+      result.current.fields.positiveNumber.setValue(2)
+    })
+
+    act(() => {
+      result.current.fields.positiveNumber.setValue(0)
+    })
+
+    const { validate } = result.current
+    let isValid = undefined
+    await act(async () => {
+      isValid = await validate()
+    })
+
+    const { fields } = result.current
+    expect(isValid).toBeFalsy()
+    expect(fields.positiveNumber.error).toEqual(
+      'This field needs to be greater than zero.'
+    )
+  })
+
+  it('should allow 0 for nonNegative rule by default', async () => {
+    type SpecificObject = { nonNegativeNumber: number }
+
+    const { result } = render<SpecificObject>({
+      nonNegativeNumber: nonNegativeNumberField()
+    })
+
+    act(() => {
+      result.current.fields.nonNegativeNumber.setValue(2)
+    })
+
+    act(() => {
+      result.current.fields.nonNegativeNumber.setValue(0)
+    })
+
+    const { validate } = result.current
+    let isValid = undefined
+    await act(async () => {
+      isValid = await validate()
+    })
+
+    const { fields } = result.current
+    expect(isValid).toBeTruthy()
+    expect(fields.nonNegativeNumber.error).toEqual(undefined)
+  })
+
+  it('should not allow -1 for nonNegative rule by default', async () => {
+    type SpecificObject = { nonNegativeNumber: number }
+
+    const { result } = render<SpecificObject>({
+      nonNegativeNumber: nonNegativeNumberField()
+    })
+
+    act(() => {
+      result.current.fields.nonNegativeNumber.setValue(2)
+    })
+
+    act(() => {
+      result.current.fields.nonNegativeNumber.setValue(-1)
+    })
+
+    const { validate } = result.current
+    let isValid = undefined
+    await act(async () => {
+      isValid = await validate()
+    })
+
+    const { fields } = result.current
+    expect(isValid).toBeFalsy()
+    expect(fields.nonNegativeNumber.error).toEqual(
+      'This field needs to be greater than or equal to zero.'
+    )
   })
 })
 

--- a/test/useForm.test.tsx
+++ b/test/useForm.test.tsx
@@ -18,19 +18,6 @@ import { aWidget, Component, Widget } from './utils'
 const noInvalidName: ValidationRule<string, any> = name =>
   name === 'InvalidName' ? "name can't be 'InvalidName'" : undefined
 
-function set<T>(field: Field<T>, value: T): void {
-  act(() => field.setValue(value))
-}
-
-async function validate<T>(currentForm: UseForm<T>): Promise<boolean> {
-  const { validate } = currentForm
-  let isValid: boolean = false
-  await act(async () => {
-    isValid = await validate()
-  })
-  return Promise.resolve(isValid)
-}
-
 describe('useForm', () => {
   it('should initialize every field as undefined by default', () => {
     const { result } = render<Widget>({
@@ -657,6 +644,19 @@ describe('useForm validation rules', () => {
     )
   })
 })
+
+function set<T>(field: Field<T>, value: T): void {
+  act(() => field.setValue(value))
+}
+
+async function validate<T>(currentForm: UseForm<T>): Promise<boolean> {
+  const { validate } = currentForm
+  let isValid: boolean = false
+  await act(async () => {
+    isValid = await validate()
+  })
+  return Promise.resolve(isValid)
+}
 
 function render<T>(
   fieldDefs: FieldDefinitions<T>,


### PR DESCRIPTION
Adding two useful number fields, as a common use-case of number fields are positive and non-negative fields.

* Add `positiveNumber` and `nonNegativeNumber` rules
* Add `positiveNumberField` and `nonNegativeNumberField` fields
* Add tests
* Update README.md
* Add `.idea` to `.gitignore` for JetBrains software users